### PR TITLE
fixing bug for Ensembl cDNA fasta

### DIFF
--- a/xpore/scripts/dataprep.py
+++ b/xpore/scripts/dataprep.py
@@ -169,7 +169,7 @@ def readFasta(transcript_fasta,is_gff):
     for entry in entries:
         entry=entry.split("\n")
         if len(entry[0].split()) > 0:
-            id=entry[0].split('.')[0]
+            id=entry[0].split(' ')[0].split('.')[0]
             seq="".join(entry[1:])
             dict[id]=[seq]
             if is_gff > 0:


### PR DESCRIPTION
The reference name would be like this. 
>`>ENST00000290810 cdna chromosome:GRCh38:16:66802878:66830976:-1 gene:ENSG00000159593.15 gene_biotype:protein_coding transcript_biotype:protein_coding gene_symbol:NAE1 description:NEDD8 activating enzyme E1 subunit 1 [Source:HGNC Symbol;Acc:HGNC:621]`

The old cold will store the transcript id as `ENST00000290810 cdna chromosome:GRCh38:16:66802878:66830976:-1 gene:ENSG00000159593`, which was not able to use in the converting transcriptome locations to genome locations.